### PR TITLE
Fixes audio visualizer color issues

### DIFF
--- a/src/components/visualization/AgentMultibandAudioVisualizer.tsx
+++ b/src/components/visualization/AgentMultibandAudioVisualizer.tsx
@@ -72,11 +72,11 @@ export const AgentMultibandAudioVisualizer = ({
       {summedFrequencies.map((frequency, index) => {
         const isCenter = index === Math.floor(summedFrequencies.length / 2);
 
-        let color = accentColor;
+        let color = `${accentColor}-${accentShade}`;
         let shadow = `shadow-lg-${accentColor}`;
         let transform;
 
-        if (state === "listening") {
+        if (state === "listening" || state === "idle") {
           color = isCenter ? `${accentColor}-${accentShade}` : "gray-950";
           shadow = !isCenter ? "" : shadow;
           transform = !isCenter ? "scale(1.0)" : "scale(1.2)";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -16,6 +16,7 @@ export interface TokenResult {
 }
 
 export type AgentState =
+  | "idle"
   | "listening"
   | "speaking"
   | "thinking"


### PR DESCRIPTION
- Color now defaults to accent color + shade color. Previously if state wasn't sent from the agent no color would render
- Add idle state handling