### PR TITLE
Update Environment Examples to point to correct repository URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ NEXT_PUBLIC_LIVEKIT_URL=wss://YOUR_LIVEKIT_URL
 NEXT_PUBLIC_APP_CONFIG="
 title: 'LiveKit Agent Playground'
 description: 'LiveKit Agent Playground allows you to test your LiveKit Agent integration by connecting to your LiveKit Cloud or self-hosted instance.'
-github_link: 'https://github.com/livekit-examples/agent-playground'
+github_link: 'https://github.com/livekit/agents-playground'
 theme_color: 'cyan'
 video_fit: 'cover' # 'contain' or 'cover'
 outputs:


### PR DESCRIPTION
Modifying https://github.com/livekit-examples/agent-playground to https://github.com/livekit/agents-playground.