### PR TITLE
Support text-only agent

### DIFF
--- a/src/components/playground/Playground.tsx
+++ b/src/components/playground/Playground.tsx
@@ -201,7 +201,7 @@ export default function Playground({
   ]);
 
   const chatTileContent = useMemo(() => {
-    if (voiceAssistant.audioTrack) {
+    if (voiceAssistant.agent) {
       return (
         <TranscriptionTile
           agentAudioTrack={voiceAssistant.audioTrack}
@@ -210,7 +210,7 @@ export default function Playground({
       );
     }
     return <></>;
-  }, [config.settings.theme_color, voiceAssistant.audioTrack]);
+  }, [config.settings.theme_color, voiceAssistant.audioTrack, voiceAssistant.agent]);
 
   const settingsTileContent = useMemo(() => {
     return (

--- a/src/transcriptions/TranscriptionTile.tsx
+++ b/src/transcriptions/TranscriptionTile.tsx
@@ -20,8 +20,7 @@ export function TranscriptionTile({
   agentAudioTrack?: TrackReferenceOrPlaceholder;
   accentColor: string;
 }) {
-  // Only use track transcription if the audio track exists
-  const agentMessages = agentAudioTrack ? useTrackTranscription(agentAudioTrack) : { segments: [] };
+  const agentMessages = useTrackTranscription(agentAudioTrack || undefined);
   const localParticipant = useLocalParticipant();
   const localMessages = useTrackTranscription({
     publication: localParticipant.microphoneTrack,

--- a/src/transcriptions/TranscriptionTile.tsx
+++ b/src/transcriptions/TranscriptionTile.tsx
@@ -17,10 +17,11 @@ export function TranscriptionTile({
   agentAudioTrack,
   accentColor,
 }: {
-  agentAudioTrack: TrackReferenceOrPlaceholder;
+  agentAudioTrack?: TrackReferenceOrPlaceholder;
   accentColor: string;
 }) {
-  const agentMessages = useTrackTranscription(agentAudioTrack);
+  // Only use track transcription if the audio track exists
+  const agentMessages = agentAudioTrack ? useTrackTranscription(agentAudioTrack) : { segments: [] };
   const localParticipant = useLocalParticipant();
   const localMessages = useTrackTranscription({
     publication: localParticipant.microphoneTrack,
@@ -36,16 +37,19 @@ export function TranscriptionTile({
 
   // store transcripts
   useEffect(() => {
-    agentMessages.segments.forEach((s) =>
-      transcripts.set(
-        s.id,
-        segmentToChatMessage(
-          s,
-          transcripts.get(s.id),
-          agentAudioTrack.participant
+    if (agentAudioTrack) {
+      agentMessages.segments.forEach((s) =>
+        transcripts.set(
+          s.id,
+          segmentToChatMessage(
+            s,
+            transcripts.get(s.id),
+            agentAudioTrack.participant
+          )
         )
-      )
-    );
+      );
+    }
+    
     localMessages.segments.forEach((s) =>
       transcripts.set(
         s.id,
@@ -59,8 +63,9 @@ export function TranscriptionTile({
 
     const allMessages = Array.from(transcripts.values());
     for (const msg of chatMessages) {
-      const isAgent =
-        msg.from?.identity === agentAudioTrack.participant?.identity;
+      const isAgent = agentAudioTrack
+        ? msg.from?.identity === agentAudioTrack.participant?.identity
+        : msg.from?.identity !== localParticipant.localParticipant.identity;
       const isSelf =
         msg.from?.identity === localParticipant.localParticipant.identity;
       let name = msg.from?.name;
@@ -86,9 +91,10 @@ export function TranscriptionTile({
     transcripts,
     chatMessages,
     localParticipant.localParticipant,
-    agentAudioTrack.participant,
+    agentAudioTrack?.participant,
     agentMessages.segments,
     localMessages.segments,
+    agentAudioTrack,
   ]);
 
   return (


### PR DESCRIPTION
Currently we block you from accessing the chat component until the agent has published an audio track, which is incompatible with agents that don't publish an audio track.

Pretty quick fix to get it working but we will probably want to make more changes as we work on 1.0

(tested with @longcw 's text stream branch as well)