### PR TITLE
Naming to easily distinguish tracks.

### DIFF
--- a/src/components/playground/Playground.tsx
+++ b/src/components/playground/Playground.tsx
@@ -69,8 +69,16 @@ export default function Playground({
 
   useEffect(() => {
     if (roomState === ConnectionState.Connected) {
-      localParticipant.setCameraEnabled(config.settings.inputs.camera);
-      localParticipant.setMicrophoneEnabled(config.settings.inputs.mic);
+      localParticipant.setCameraEnabled(
+        config.settings.inputs.camera,
+        undefined,
+        { name: "camera" }
+      );
+      localParticipant.setMicrophoneEnabled(
+        config.settings.inputs.mic,
+        undefined,
+        { name: "mic" }
+      );
     }
   }, [config, localParticipant, roomState]);
 


### PR DESCRIPTION
Naming to distinguish tracks (specifically camera and screen share).

- Still working on naming the screen share track in a reliable way. Have not yet found how to do that. Instead for the time being I am initializing screen share alongside camera and mic which works for my purposes. Would love to know how I can name the screen share track in its current state.